### PR TITLE
feat(error): generic error handler for API requests

### DIFF
--- a/server/lib/helpers/ApiError.js
+++ b/server/lib/helpers/ApiError.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const ApiErrorCodes = {
+  serverError: 'SERVER_ERROR'
+}
+
+class ApiError extends Error {
+  constructor (message, {status, code} = {}) {
+    super(message)
+
+    // Set Generic error message
+    this.message = message
+
+    // Set HTTP status code
+    this.status = status || 500
+
+    // Set API error code
+    this.code = code || ApiErrorCodes.serverError
+
+    // Ensures that stack trace uses our subclass name
+    this.name = this.constructor.name
+
+    // Ensures the ApiError subclass is sliced out of the
+    // stack trace dump for clarity
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+module.exports = ApiError

--- a/server/lib/helpers/ApiError.js
+++ b/server/lib/helpers/ApiError.js
@@ -8,9 +8,6 @@ class ApiError extends Error {
   constructor (message, {status, code} = {}) {
     super(message)
 
-    // Set Generic error message
-    this.message = message
-
     // Set HTTP status code
     this.status = status || 500
 

--- a/server/lib/services/express.js
+++ b/server/lib/services/express.js
@@ -166,8 +166,12 @@ module.exports.initErrorRoutes = function (app) {
     // Log it
     console.error(err.stack);
 
-    // Redirect to error page
-    res.status(500).send();
+    // Build an error response object and send it with the
+    // status in the error
+    res.status(err.status).send({
+      message: err.message,
+      code: err.code
+    });
   });
 };
 

--- a/server/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/server/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -5,6 +5,7 @@
  */
 const path = require('path')
 const config = require(path.resolve('./lib/config'))
+const ApiError = require(path.resolve('./lib/helpers/ApiError'))
 const errorHandler = require(path.resolve('./modules/core/server/controllers/errors.server.controller'))
 const mongoose = require('mongoose')
 const passport = require('passport')
@@ -22,12 +23,12 @@ var noReturnUrls = [
 /**
  * Signup
  */
-exports.signup = async function (req, res) {
+exports.signup = async function (req, res, next) {
   try {
     const user = await UserService.signUp(req.body)
     return res.json(user)
   } catch (err) {
-    return res.status(500).send(err.message)
+    return next(new ApiError(err.message))
   }
 }
 
@@ -49,7 +50,7 @@ exports.signout = function (req, res) {
 /**
  * Jwt Token Auth
  */
-exports.token = async function (req, res) {
+exports.token = async function (req, res, next) {
   try {
     // Authenticate the user based on credentials
     // @TODO be consistent with whether the login field for user identification
@@ -69,7 +70,7 @@ exports.token = async function (req, res) {
 
     res.status(200).json({token: token})
   } catch (err) {
-    return res.status(500).send(err.message)
+    return next(new ApiError(err.message))
   }
 }
 


### PR DESCRIPTION
Adding a generic API error handler that builds on Express's error middleware to separate concerns and take actions based on specific errors (i.e: log the, stack trace, etc), instead of handling this per route.