### PR TITLE
fix(config): Local Environment config file

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -22,8 +22,8 @@ coverage/
 public/dist/
 uploads
 modules/users/client/img/profile/uploads
-config/env/local.js
-config/env/local-*.js
+*/config/env/local.js
+*/config/env/local-*.js
 *.pem
 
 # Compiled less and sass files

--- a/server/gulpfile.js
+++ b/server/gulpfile.js
@@ -110,15 +110,16 @@ gulp.task('eslint', function () {
 gulp.task('copyLocalEnvConfig', function () {
   var src = [];
   var renameTo = 'local-development.js';
+  var destination = path.join(process.cwd(), 'lib/config/env');
 
   // only add the copy source if our destination file doesn't already exist
-  if (!fs.existsSync('config/env/' + renameTo)) {
-    src.push('config/env/local.example.js');
+  if (!fs.existsSync(destination + '/' + renameTo)) {
+    src.push(destination + '/local.example.js');
   }
 
   return gulp.src(src)
     .pipe(plugins.rename(renameTo))
-    .pipe(gulp.dest('config/env'));
+    .pipe(gulp.dest(destination));
 });
 
 // Make sure upload directory exists

--- a/server/lib/config/index.js
+++ b/server/lib/config/index.js
@@ -188,7 +188,7 @@ var initGlobalConfig = function () {
   config.meanjs = pkg;
 
   // Extend the config object with the local-NODE_ENV.js custom/local environment. This will override any settings present in the local configuration.
-  // config = _.merge(config, (fs.existsSync(path.join(process.cwd(), 'config/env/local-' + process.env.NODE_ENV + '.js')) && require(path.join(process.cwd(), 'config/env/local-' + process.env.NODE_ENV + '.js'))) || {});
+  config = _.merge(config, (fs.existsSync(path.join(process.cwd(), 'lib/config/env/local-' + process.env.NODE_ENV + '.js')) && require(path.join(process.cwd(), 'lib/config/env/local-' + process.env.NODE_ENV + '.js'))) || {});
 
   // Initialize global globbed files
   initGlobalConfigFiles(config, assets);

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "update": "npm update && npm prune",
     "clean": "rm -rf node_modules/",
     "reinstall": "npm cache clean && npm run clean && npm install",
+    "gulp": "gulp",
     "start": "node server.js",
     "start:debug": "nodemon --inspect server.js",
     "test": "gulp test",


### PR DESCRIPTION
Fixes, and uncomments the line that merges an existing "local-ENV" file
with the loaded configuration.

Fixes an issue with the Gulp `copyLocalEnvConfig` task caused by the
incorrect path being used.

Added "gulp" npm script in order to use the package's installed version
of Gulp with `npm run gulp [task]`.

e.g. `npm run gulp copyLocalEnvConfig`.